### PR TITLE
Add VPC collector to support VPC Flow Log Auditor re-write

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,7 @@ Update the list of the following resources for a specific account and region
 * EBS Volumes
 * EBS Snapshots
 * Elastic BeanStalks
+* VPCs
 
 =====================
 Configuration Options

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     setup_requires=['setuptools_scm'],
     install_requires=[
-        'cloud_inquisitor>=1.0.0',
+        'cloud_inquisitor>=1.0.2',
         'boto3>=1.4.4',
         'botocore>=1.5.52',
         'python-dateutil>=2.6.0',


### PR DESCRIPTION
This adds collection and storage of various VPC attributes as part of the flow log auditor rewrite with the current schema.

