### PR TITLE
Route53 ALIAS records consistency fix

### DIFF
--- a/cinq_collector_aws/account.py
+++ b/cinq_collector_aws/account.py
@@ -406,7 +406,7 @@ class AWSAccountCollector(BaseCollector):
                                 'name': record['Name'],
                                 'type': 'ALIAS',
                                 'ttl': 0,
-                                'value': value
+                                'value': [value]
                             }
                         else:
                             value = [y['Value'] for y in record['ResourceRecords']]


### PR DESCRIPTION
ALIAS records are currently the only type of DNSRecord not storing the value of the record as a list, causing possible issues with the hijack checker. This PR fixes this and ensures that the value stored should always be a `list` object.