### PR TITLE
bug: Region-based search in EBS Volumes broken

### DIFF
--- a/cinq_collector_aws/views/ebs_volumes.py
+++ b/cinq_collector_aws/views/ebs_volumes.py
@@ -45,7 +45,7 @@ class EBSVolumeList(BaseView):
             query['accounts'] = args['accounts']
 
         if args['regions']:
-            query['location'] = args['regions']
+            query['locations'] = args['regions']
 
         if args['state'] and len(args['state']) > 0:
             query['properties']['state'] = args['state']


### PR DESCRIPTION
Region-based search for EBS volumes returned red message "search() got an unexpected keyword argument 'location' "

Fix by using 'locations' key in query dictionary (rather than 'location').